### PR TITLE
Add href attributes to the anchor tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,12 +260,12 @@ article {
     <h3 class="card-title">Introduction to jaguar</h3>
   </a>
 
-  <a class="card">
+  <a class="card" href="https://www.dartdocs.org/documentation/jaguar/0.1.0/index.html">
     <div class="card-icon card-icon-api"></div>
     <h3 class="card-title">API docs</h3>
   </a>
 
-  <a class="card">
+  <a class="card" href="https://github.com/Jaguar-dart">
     <div class="card-icon card-icon-examples"></div>
     <h3 class="card-title">Browse examples</h3>
   </a>


### PR DESCRIPTION
The href attributes on the 'Examples' and 'API Docs' anchor tags were missing.